### PR TITLE
Add React frontend scaffold

### DIFF
--- a/ai-frontend/README.md
+++ b/ai-frontend/README.md
@@ -1,0 +1,31 @@
+# AI Frontend
+
+This folder contains a simple React + Tailwind application scaffolded to match provided UI mockups.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Start development server:
+   ```bash
+   npm run dev
+   ```
+
+3. Build for production:
+   ```bash
+   npm run build
+   ```
+
+Tailwind is configured via `tailwind.config.js` and `postcss.config.js`. Styles are imported in `src/input.css` and compiled to `dist/output.css`.
+
+The main React entry is `src/main.jsx`. Components reside in `src/components`:
+- `Chat.jsx` – main chat window
+- `Documents.jsx` – file uploads and listing
+- `Settings.jsx` – configuration form
+- `Sidebar.jsx` – navigation between sections
+
+The layout and styling should be adjusted to match the provided JPEG mockups.
+\n## Backend Integration\n\nThe chat messages should be sent to your backend API for processing (e.g., Python service with Pinecone indexing). Use `fetch` or Axios in the React components to communicate with endpoints for chat, file upload, and settings storage.

--- a/ai-frontend/package.json
+++ b/ai-frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ai-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.3.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.2",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/ai-frontend/postcss.config.js
+++ b/ai-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/ai-frontend/src/App.jsx
+++ b/ai-frontend/src/App.jsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import Chat from './components/Chat';
+import Documents from './components/Documents';
+import Settings from './components/Settings';
+import Sidebar from './components/Sidebar';
+
+export default function App() {
+  const [view, setView] = useState('chat');
+
+  let content;
+  if (view === 'documents') content = <Documents />;
+  else if (view === 'settings') content = <Settings />;
+  else content = <Chat />;
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar view={view} setView={setView} />
+      <div className="flex-1 overflow-hidden">{content}</div>
+    </div>
+  );
+}

--- a/ai-frontend/src/components/Chat.jsx
+++ b/ai-frontend/src/components/Chat.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function Chat() {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-auto p-4" id="chat-window">
+        {/* Messages will appear here */}
+      </div>
+      <div className="p-4 border-t">
+        <input type="text" placeholder="Type your message..." className="w-full p-2 border rounded" />
+      </div>
+    </div>
+  );
+}

--- a/ai-frontend/src/components/Documents.jsx
+++ b/ai-frontend/src/components/Documents.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Documents() {
+  return (
+    <div className="p-4 space-y-4">
+      <button className="px-4 py-2 bg-blue-500 text-white rounded">Upload File</button>
+      {/* File list placeholder */}
+      <ul className="space-y-2">
+        <li>No files uploaded.</li>
+      </ul>
+    </div>
+  );
+}

--- a/ai-frontend/src/components/Settings.jsx
+++ b/ai-frontend/src/components/Settings.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function Settings() {
+  return (
+    <div className="p-4 space-y-4">
+      <label className="block">
+        API Key
+        <input type="text" className="mt-1 p-2 border rounded w-full" />
+      </label>
+      <label className="flex items-center space-x-2">
+        <input type="checkbox" />
+        <span>Enable Notifications</span>
+      </label>
+    </div>
+  );
+}

--- a/ai-frontend/src/components/Sidebar.jsx
+++ b/ai-frontend/src/components/Sidebar.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function Sidebar({ view, setView }) {
+  return (
+    <div className="w-48 bg-gray-800 text-white flex flex-col p-4 space-y-4">
+      <button className={view==='chat' ? 'font-bold' : ''} onClick={() => setView('chat')}>Chat</button>
+      <button className={view==='documents' ? 'font-bold' : ''} onClick={() => setView('documents')}>Documents</button>
+      <button className={view==='settings' ? 'font-bold' : ''} onClick={() => setView('settings')}>Settings</button>
+    </div>
+  );
+}

--- a/ai-frontend/src/input.css
+++ b/ai-frontend/src/input.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/ai-frontend/src/main.jsx
+++ b/ai-frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './input.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ai-frontend/tailwind.config.js
+++ b/ai-frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add `ai-frontend` folder with React and Tailwind scaffolding
- include Chat, Documents, Settings, and Sidebar components
- provide Tailwind and PostCSS config
- document setup instructions in README

## Testing
- `git status --short`